### PR TITLE
Add VERSION to Manifest.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE.txt
+include VERSION


### PR DESCRIPTION
On python 3.6 this fails to install because of a missing VERSION file. This should fix it.