### PR TITLE
Fix vulnerable dependency issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-PyYAML==3.13
+PyYAML==5.1


### PR DESCRIPTION
Update the requirements.txt to ensure the latest secure version of pyyaml is used. 

ERROR: frontmatter 3.0.5 has requirement PyYAML==3.13, but you'll have pyyaml 5.1 which is incompatible.