### PR TITLE
Specify a loader when loading YAML

### DIFF
--- a/frontmatter/__init__.py
+++ b/frontmatter/__init__.py
@@ -34,7 +34,7 @@ class Frontmatter:
             fmatter = result.group(1)
             body = result.group(2)
         return {
-            "attributes": yaml.load(fmatter),
+            "attributes": yaml.load(fmatter, Loader=yaml.FullLoader),
             "body": body,
             "frontmatter": fmatter,
         }


### PR DESCRIPTION
This addresses the following deprecation warning when loading the YAML:

```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the
default Loader is unsafe. Please read https://msg.pyyaml.org/load for full
details.
```

This change uses the `yaml.FullLoader` which avoids arbitrary code execution and is the default loader called by `yaml.load(input)`.