### PR TITLE
Regex improvements

### DIFF
--- a/frontmatter/__init__.py
+++ b/frontmatter/__init__.py
@@ -2,7 +2,7 @@ import re
 import yaml
 
 class Frontmatter:
-    _yaml_delim = r'(?m:^---|\+\+\+$)'
+    _yaml_delim = r'(?m:^---$)'
     _yaml = r'(.*?)'
     _content = r'\s*(.+)$'
     _re_pattern = r'^\s*' + _yaml_delim + _yaml + _yaml_delim + _content

--- a/frontmatter/__init__.py
+++ b/frontmatter/__init__.py
@@ -6,7 +6,7 @@ class Frontmatter:
     _yaml = r'(.*?)'
     _content = r'\s*(.+)$'
     _re_pattern = r'^\s*' + _yaml_delim + _yaml + _yaml_delim + _content
-    _regex = re.compile(_re_pattern, re.S | re.M)
+    _regex = re.compile(_re_pattern, re.S)
 
     @classmethod
     def read_file(cls, path):

--- a/frontmatter/__init__.py
+++ b/frontmatter/__init__.py
@@ -2,7 +2,7 @@ import re
 import yaml
 
 class Frontmatter:
-    _yaml_delim = r'(?:---|\+\+\+)'
+    _yaml_delim = r'(?m:^---|\+\+\+$)'
     _yaml = r'(.*?)'
     _content = r'\s*(.+)$'
     _re_pattern = r'^\s*' + _yaml_delim + _yaml + _yaml_delim + _content


### PR DESCRIPTION
- Remove global multiline flag to ensure matching the whole string
- Use local multiline flag to restrict delimiter
- Don't match on TOML delimiter (`+++`) as it is currently only interpreted as YAML